### PR TITLE
textlint-rule-max-kanji-continuous-lenで許可する単語を追加

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -4,7 +4,14 @@
   ],
   "filters": {},
   "rules": {
-    "preset-ja-technical-writing": true,
+    "preset-ja-technical-writing": {
+      "max-kanji-continuous-len": {
+        "allow": [
+          "自己実行無名関数",
+          "即時実行関数式"
+        ]
+      }
+    },
     "textlint-rule-ja-space-between-half-and-full-width": {
       "space": "always"
     },


### PR DESCRIPTION
issue https://github.com/mozilla-japan/translation/issues/656 対応中に本リポジトリのtextlintの設定を使わせてもらってます🙏

[textlint-rule-preset-ja-technical-writing](https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing#%E9%80%A3%E7%B6%9A%E3%81%A7%E3%81%8D%E3%82%8B%E6%9C%80%E5%A4%A7%E3%81%AE%E6%BC%A2%E5%AD%97%E9%95%B7%E3%81%AF6%E6%96%87%E5%AD%97%E3%81%BE%E3%81%A7)に含まれている[textlint-rule-max-kanji-continuous-len](https://github.com/textlint-ja/textlint-rule-max-kanji-continuous-len)のルールに引っかかる単語が合ったため、許可するようにルールを更新しました。